### PR TITLE
Add repository settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: crbgc
+  description: "a website for the Common & Recent Bogey Golf Club"
+  homepage: https://crbgc.org/


### PR DESCRIPTION
Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).

This config extends the base settings from `philoserf/.github` and includes repo-specific metadata and overrides.

Settings are applied automatically when the Settings app is installed and this PR is merged.