### PR TITLE
Converge palette with design note (Masters green); biome schema latest

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2,7 +2,7 @@
   --fg: #1a1a1a;
   --muted: #595959;
   --bg: #fafaf7;
-  --accent: #2f5d3a;
+  --accent: #006747;
   --rule: #d8d4c7;
   --measure: 38rem;
 }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "files": {
     "includes": ["assets/**/*.css"]
   },


### PR DESCRIPTION
Converges the club site with the "Web Design for Golf" note (modern/editorial direction), and stops the biome config from churning on version bumps.

## Changes
- **style.css**: `--accent` → Masters Green `#006747` (was `#2f5d3a`). Cream `#FAFAF7` background, near-black `#1A1A1A` body, serif prose / sans headings all unchanged — green stays the accent for links, rules, and callouts.
- **biome.json**: `$schema` → `.../latest/schema.json` so it tracks the installed CLI without per-version diffs.

## Notes
- Sibling repo `crbgc-notes` gets the same accent in its PR (#15) for a consistent palette across both sites.