### PR TITLE
Distinguish informal 2000 formation from official 2026 establishment

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,11 +1,11 @@
 ---
 title: "The Common & Recent Bogey Golf Club"
-description: "A small parliamentary golf society founded circa 2000."
+description: "A small parliamentary golf society informally formed in 2000 and officially established in 2026."
 draft: false # exempt from the Reformation-Year draft cascade (see hugo.toml); keeps a live landing page
 ---
 
 # The Common & Recent Bogey Golf Club
 
-Established circa 2000 by [Mark Ayers](https://philoserf.com/) and [Dean Chase](https://deanisthedevil.com/).
+Informally formed in the summer of 2000 by [Mark Ayers](https://philoserf.com/) and [Dean Chase](https://deanisthedevil.com/); officially established in the summer of 2026.
 
 > We can make bogey here, right?

--- a/content/governance/bylaws.md
+++ b/content/governance/bylaws.md
@@ -20,7 +20,7 @@ The Object of the Club shall be to promote the ancient art of taking a pleasant 
 
 **Section 1. Classes.** The Club shall have two classes of members: Charter Members and Members. Each is a "Member" for purposes of these Bylaws.
 
-**Section 2. Charter Members.** The Charter Members of the Club are **Mark Ayers** and **Dean Chase**, who founded the Club circa 2000. Charter membership is for life and may not be revoked.
+**Section 2. Charter Members.** The Charter Members of the Club are **Mark Ayers** and **Dean Chase**, who informally formed the Club in the summer of 2000; the Club was officially established in the summer of 2026. Charter membership is for life and may not be revoked.
 
 **Section 3. Admission of Members.** A person may be admitted as a Member only upon the unanimous affirmative vote of all then-living Charter Members.
 


### PR DESCRIPTION
The homepage and bylaws said only "circa 2000," which conflates the Club's **informal formation** with its **official establishment**. This records both dates:

- **Informally formed:** summer 2000, by Charter Members Mark Ayers and Dean Chase.
- **Officially established:** summer 2026 — the Reformation Year, when the bylaws and standing rules are instituted.

## Changes

- **`content/_index.md`** — description and intro line now state informal-2000 / official-2026.
- **`content/governance/bylaws.md` §2** — Charter Members clause records both the informal formation and the official establishment.

Renders via `--buildDrafts` (governance pages remain under the Reformation-Year draft cascade); the homepage is exempt and live.