### PR TITLE
Add llms.txt output for the governance site

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,3 +17,12 @@ endLevel = 3
 notices = "/notices/:slug/"
 minutes = "/minutes/:slug/"
 news = "/news/:slug/"
+
+[outputFormats.llms]
+mediaType = "text/plain"
+baseName = "llms"
+isPlainText = true
+notAlternative = true
+
+[outputs]
+home = ["html", "rss", "llms"]

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,23 @@
+{{- define "llms-section" -}}
+{{- with .pages }}
+## {{ $.heading }}
+{{ range . }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ else }}{{ with .Date }} — {{ .Format "2006-01-02" }}{{ end }}{{ end }}
+{{- end }}
+{{ end -}}
+{{- end -}}
+# {{ .Site.Title }}
+
+> {{ .Description }}
+
+The formal governance site of the Common & Recent Bogey Golf Club — bylaws, official notices, meeting minutes, and news. The club's informal notes (history, course architecture, courses to play) live separately at https://crbgc-philoserf.flowershow.me.
+
+Base URL: {{ .Site.BaseURL }}
+{{ with (.Site.GetPage "/governance") }}{{ template "llms-section" (dict "heading" "Governance" "pages" .Pages.ByWeight) }}{{ end -}}
+{{- with (.Site.GetPage "/notices") }}{{ template "llms-section" (dict "heading" "Notices" "pages" (first 15 .RegularPages.ByDate.Reverse)) }}{{ end -}}
+{{- with (.Site.GetPage "/minutes") }}{{ template "llms-section" (dict "heading" "Minutes" "pages" (first 15 .RegularPages.ByDate.Reverse)) }}{{ end -}}
+{{- with (.Site.GetPage "/news") }}{{ template "llms-section" (dict "heading" "News" "pages" (first 15 .RegularPages.ByDate.Reverse)) }}{{ end }}
+## Feeds
+
+- [RSS]({{ "index.xml" | absURL }})
+- [Sitemap]({{ "sitemap.xml" | absURL }})


### PR DESCRIPTION
Adds an [`llms.txt`](https://llmstxt.org/) at the site root, generated by Hugo — the same custom-output-format approach used in [philoserf/site](https://github.com/philoserf/site).

## How
- New `[outputFormats.llms]` in `hugo.toml` (`text/plain`, `baseName = "llms"`) added to the home page's `outputs`.
- New `layouts/index.llms.txt` template renders the file from site content:
  - **Governance** documents in weight order, with descriptions
  - **Notices**, **Minutes**, **News** — most recent first, by date
  - **Feeds** — RSS and sitemap

## Behavior notes
- Empty sections are suppressed. Production builds omit `--buildFuture`, so the June 21 organizational records (notices/minutes/news, all dated 2026-06-21) aren't live yet and correctly don't appear; they'll roll into `llms.txt` automatically when the daily deploy picks them up. Verified by building with and without `--buildFuture`.
- `.txt` is outside the Prettier glob (it's a Go template), so `task check` doesn't touch it. The one pre-existing `walkthrough.md` format warning is unrelated to this change.

Generated output (production, today):

```
# The Common & Recent Bogey Golf Club

> A small parliamentary golf society informally formed in 2000 and officially established in 2026.

...

## Governance

- [Bylaws](https://crbgc.org/governance/bylaws/): Bylaws of the Common & Recent Bogey Golf Club, adopted June 21, 2026.
- [Standing Rules](https://crbgc.org/governance/standing-rules/): ...
- [Special Rules of Order](https://crbgc.org/governance/special-rules-of-order/): ...
- [Officers](https://crbgc.org/governance/officers/): ...

## Feeds

- [RSS](https://crbgc.org/index.xml)
- [Sitemap](https://crbgc.org/sitemap.xml)
```