### PR TITLE
Rewrite homepage intro and add a statement of purpose

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,6 +5,8 @@ description: "A small parliamentary golf society informally formed in 2000 and o
 
 # The Common & Recent Bogey Golf Club
 
-Informally formed in the summer of 2000 by [Mark Ayers](https://philoserf.com/) and [Dean Chase](https://deanisthedevil.com/); officially established in the summer of 2026.
+[Mark Ayers](https://philoserf.com/) and [Dean Chase](https://deanisthedevil.com/) formed the club informally in the summer of 2000. It was officially established in the summer of 2026.
+
+For twenty-five years, on the courses we walked together and with friends, we settled between us what golf is: the common game, played honestly, where a bogey is a good score and no disgrace. The game that has grown up around us — royal, ancient, scratch or nothing — has forgotten that. We have not. Now formally established, we put the case to anyone who has felt the same on the tee.
 
 > We can make bogey here, right?

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,6 +7,6 @@ description: "A small parliamentary golf society informally formed in 2000 and o
 
 [Mark Ayers](https://philoserf.com/) and [Dean Chase](https://deanisthedevil.com/) formed the club informally in the summer of 2000. It was officially established in the summer of 2026.
 
-For twenty-five years, on the courses we walked together and with friends, we settled between us what golf is: the common game, played honestly, where a bogey is a good score and no disgrace. The game that has grown up around us — royal, ancient, scratch or nothing — has forgotten that. We have not. Now formally established, we put the case to anyone who has felt the same on the tee.
+For twenty-six years, on the courses we walked together and with friends, we settled between us what golf is: the common game, played honestly, where a bogey is a good score and no disgrace. The game that has grown up around us — royal, ancient, scratch or nothing — has forgotten that. We have not. Now formally established, we put the case to anyone who has felt the same on the tee.
 
 > We can make bogey here, right?


### PR DESCRIPTION
## What

- Turn the formation line into complete sentences (it was a subjectless caption-style fragment).
- Add a short statement of purpose: what the club takes golf to be — the common game, where a bogey is a good score and no disgrace — and why it offers that view now.

## Notes

- Prose edited to The Economist's style rules: plain words, active voice, dead metaphors cut, one em-dash aside kept where it carries the name's joke (Common & Recent / Royal & Ancient).
- US spelling kept deliberately; the club and site are American.
- Homepage `h1` left as-is per the standing design choice.